### PR TITLE
Feat: 실시간 채팅 기능 구현 (#8)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//chatting
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework:spring-messaging'
+	implementation 'com.fasterxml.jackson.core:jackson-core'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 // Spotless 설정 (코드 스타일 자동 정리 도구)

--- a/src/main/java/com/kgu/life_watch/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kgu/life_watch/domain/auth/service/AuthService.java
@@ -11,6 +11,8 @@ import com.kgu.life_watch.domain.auth.dto.SocialWorkerSignUpRequest;
 import com.kgu.life_watch.domain.user.entity.ElderlyProfile;
 import com.kgu.life_watch.domain.user.entity.SocialWorkerProfile;
 import com.kgu.life_watch.domain.user.entity.User;
+import com.kgu.life_watch.domain.user.repository.ElderlyProfileRepository;
+import com.kgu.life_watch.domain.user.repository.SocialWorkerProfileRepository;
 import com.kgu.life_watch.domain.user.repository.UserRepository;
 import com.kgu.life_watch.global.exception.ErrorCode;
 import com.kgu.life_watch.global.exception.LifelineException;
@@ -20,6 +22,8 @@ import com.kgu.life_watch.global.jwt.JwtTokenProvider;
 @RequiredArgsConstructor
 public class AuthService {
   private final UserRepository userRepository;
+  private final ElderlyProfileRepository elderlyProfileRepository;
+  private final SocialWorkerProfileRepository socialWorkerProfileRepository;
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
 
@@ -53,8 +57,7 @@ public class AuthService {
             .protectorContact(request.protectorContact())
             .build();
 
-    user.setElderlyProfile(elderlyProfile); // 양방향 연관관계 설정
-    userRepository.save(user);
+    elderlyProfileRepository.save(elderlyProfile);
   }
 
   public void signUpSocialWorker(SocialWorkerSignUpRequest request) {
@@ -80,8 +83,7 @@ public class AuthService {
     SocialWorkerProfile workerProfile =
         SocialWorkerProfile.builder().user(user).assignedElderId(request.assignedElderId()).build();
 
-    user.setSocialWorkerProfile(workerProfile);
-    userRepository.save(user);
+    socialWorkerProfileRepository.save(workerProfile);
   }
 
   public String login(LoginRequest request) {

--- a/src/main/java/com/kgu/life_watch/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/controller/ChatMessageController.java
@@ -1,0 +1,36 @@
+package com.kgu.life_watch.domain.chat.controller;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.kgu.life_watch.domain.chat.dto.ChatMessageDto;
+import com.kgu.life_watch.domain.chat.dto.response.ChatMessageResponse;
+import com.kgu.life_watch.domain.chat.entity.ChatMessage;
+import com.kgu.life_watch.domain.chat.service.ChatMessageService;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class ChatMessageController {
+
+  private final ChatMessageService chatMessageService;
+  private final SimpMessagingTemplate messagingTemplate;
+
+  @MessageMapping("/message")
+  public void sendMessage(@Valid ChatMessageDto request, SimpMessageHeaderAccessor accessor) {
+    String userId = (String) accessor.getSessionAttributes().get("senderUserId");
+    // 실시간으로 방에서 채팅하기
+    ChatMessage newChatMessage = chatMessageService.createChatMessage(request, userId);
+    log.info("received message: {}", request);
+
+    // 방에 있는 모든 사용자에게 메시지 전송
+    messagingTemplate.convertAndSend(
+        "/sub/channel/" + request.roomId(), ChatMessageResponse.fromEntity(newChatMessage));
+  }
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/controller/ChatRoomController.java
@@ -1,0 +1,61 @@
+package com.kgu.life_watch.domain.chat.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+import com.kgu.life_watch.domain.chat.dto.response.ChatMessageResponse;
+import com.kgu.life_watch.domain.chat.dto.response.ChatRoomResponse;
+import com.kgu.life_watch.domain.chat.service.ChatMessageService;
+import com.kgu.life_watch.domain.chat.service.ChatRoomService;
+import com.kgu.life_watch.global.domain.SuccessCode;
+import com.kgu.life_watch.global.dto.response.ApiResponse;
+import com.kgu.life_watch.global.security.CustomUserDetails;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat-room")
+public class ChatRoomController {
+
+  private final ChatRoomService chatRoomService;
+  private final ChatMessageService chatMessageService;
+
+  @GetMapping("/create")
+  @Operation(summary = "채팅방 생성 API", description = "채팅방을 생성하는 API입니다.")
+  public ApiResponse<ChatRoomResponse> createChatRoom(
+      @AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam Long receiverId) {
+    return new ApiResponse<>(chatRoomService.createChatRoom(userDetails.user(), receiverId));
+  }
+
+  @GetMapping("/list")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(summary = "참여중인 채팅방 조회 API", description = "본인이 참여중인 채팅방을 조회하는 API입니다.")
+  public ApiResponse<ChatRoomResponse> getMessagesByRoom(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return new ApiResponse<>(chatRoomService.getAllRoom(userDetails.user()));
+  }
+
+  @DeleteMapping("/delete/{roomId}")
+  @Operation(summary = "채팅방 나가기(삭제) API", description = "채팅방을 나가기(삭제)하는 API입니다.")
+  public ApiResponse<Void> deleteRoom(
+      @PathVariable("roomId") Long roomId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    chatRoomService.deleteRoom(roomId, userDetails.user());
+    return new ApiResponse<>(SuccessCode.REQUEST_OK);
+  }
+
+  @GetMapping("/messages/{roomId}")
+  @Operation(summary = "채팅방 전체 메시지 조회 API", description = "특정 채팅방의 모든 메시지를 조회하는 API입니다.")
+  public ApiResponse<ChatMessageResponse> getAllMessagesByRoom(
+      @PathVariable("roomId") Long roomId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return new ApiResponse<>(chatMessageService.getMessagesByRoom(roomId, userDetails.user()));
+  }
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/dto/ChatMessageDto.java
@@ -1,0 +1,29 @@
+package com.kgu.life_watch.domain.chat.dto;
+
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+import com.kgu.life_watch.domain.chat.entity.ChatMessage;
+import com.kgu.life_watch.domain.chat.entity.ChatRoom;
+import com.kgu.life_watch.domain.user.entity.User;
+
+@Builder
+public record ChatMessageDto(
+    Long roomId,
+    @NotBlank(message = "메시지는 필수입니다.")
+        @Size(min = 1, max = 200, message = "메시지는 최소 1자, 최대 200자까지 입력 가능합니다.")
+        String message) {
+  /* Dto -> Entity */
+  public ChatMessage toEntity(ChatRoom chatRoom, User sender) {
+    return ChatMessage.builder()
+        .chatRoom(chatRoom)
+        .sender(sender)
+        .senderName(sender.getName())
+        .message(message)
+        .createdAt(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/dto/ChatMessageDto.java
@@ -1,7 +1,5 @@
 package com.kgu.life_watch.domain.chat.dto;
 
-import java.time.LocalDateTime;
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -23,7 +21,6 @@ public record ChatMessageDto(
         .sender(sender)
         .senderName(sender.getName())
         .message(message)
-        .createdAt(LocalDateTime.now())
         .build();
   }
 }

--- a/src/main/java/com/kgu/life_watch/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,31 @@
+package com.kgu.life_watch.domain.chat.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Size;
+
+import com.kgu.life_watch.domain.chat.entity.ChatMessage;
+
+public record ChatMessageResponse(
+    @Size(min = 1, max = 200, message = "메시지는 최소 1자, 최대 200자까지 입력 가능합니다.") String message,
+    Long senderId,
+    Long roomId,
+    String senderName,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime createdAt) {
+
+  public static ChatMessageResponse fromEntity(ChatMessage chatMessage) {
+    return new ChatMessageResponse(
+        chatMessage.getMessage(),
+        chatMessage.getSender().getId(),
+        chatMessage.getChatRoom().getId(),
+        chatMessage.getSenderName(),
+        chatMessage.getCreatedAt());
+  }
+
+  public static List<ChatMessageResponse> fromEntitieList(List<ChatMessage> chatMessages) {
+    return chatMessages.stream().map(ChatMessageResponse::fromEntity).toList();
+  }
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/dto/response/ChatRoomResponse.java
@@ -1,0 +1,33 @@
+package com.kgu.life_watch.domain.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+import com.kgu.life_watch.domain.chat.entity.ChatMessage;
+import com.kgu.life_watch.domain.chat.entity.ChatRoom;
+import com.kgu.life_watch.domain.user.entity.User;
+
+@Builder
+public record ChatRoomResponse(
+    Long roomId,
+    Long receiverId,
+    String receiverName,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime createdAt,
+    String lastMessage,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime lastMessageAt) {
+  public static ChatRoomResponse fromEntity(
+      ChatRoom savedChatRoom, User receiver, ChatMessage chatMessage) {
+    return ChatRoomResponse.builder()
+        .roomId(savedChatRoom.getId())
+        .receiverId(receiver.getId())
+        .receiverName(receiver.getName())
+        .createdAt(savedChatRoom.getCreatedAt())
+        .lastMessage(chatMessage != null ? chatMessage.getMessage() : null)
+        .lastMessageAt(chatMessage != null ? chatMessage.getCreatedAt() : null)
+        .build();
+  }
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/entity/ChatMessage.java
@@ -41,7 +41,7 @@ public class ChatMessage {
   private User sender;
 
   @Column(nullable = false)
-  private String sender_name;
+  private String senderName;
 
   @Column(nullable = false)
   private String message;

--- a/src/main/java/com/kgu/life_watch/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,50 @@
+package com.kgu.life_watch.domain.chat.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.kgu.life_watch.domain.user.entity.User;
+
+@Entity
+@Table
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatMessage {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "room_id", nullable = false)
+  private ChatRoom chatRoom;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "sender_id", nullable = false)
+  private User sender;
+
+  @Column(nullable = false)
+  private String sender_name;
+
+  @Column(nullable = false)
+  private String message;
+
+  @CreationTimestamp
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/entity/ChatMessage.java
@@ -14,11 +14,13 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 import com.kgu.life_watch.domain.user.entity.User;
 
+@Getter
 @Entity
 @Table
 @Builder

--- a/src/main/java/com/kgu/life_watch/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,72 @@
+package com.kgu.life_watch.domain.chat.entity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.kgu.life_watch.domain.chat.entity.mapping.ChatParticipation;
+
+@Entity
+@Table
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatRoom {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private String id;
+
+  @Column
+  @Enumerated(EnumType.STRING)
+  private RoomStatus status; // 채팅방 상태
+
+  @CreationTimestamp
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<ChatParticipation> participation; // 채팅방의 참여 정보
+
+  @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+  private List<ChatMessage> messages;
+
+  public List<ChatMessage> getChatMessages() {
+    return messages;
+  }
+
+  public void addParticipation(ChatParticipation chatParticipation) {
+    if (participation == null) {
+      participation = new ArrayList<>();
+    }
+    participation.add(chatParticipation);
+  }
+
+  public void addMessage(ChatMessage chatMessage) {
+    if (messages == null) {
+      messages = new ArrayList<>();
+    }
+    messages.add(chatMessage);
+  }
+
+  public void updateStatus(RoomStatus roomStatus) {
+    this.status = roomStatus;
+  }
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/entity/ChatRoom.java
@@ -18,11 +18,13 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 import com.kgu.life_watch.domain.chat.entity.mapping.ChatParticipation;
 
+@Getter
 @Entity
 @Table
 @Builder
@@ -32,7 +34,7 @@ public class ChatRoom {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private String id;
+  private Long id;
 
   @Column
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/kgu/life_watch/domain/chat/entity/RoomStatus.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/entity/RoomStatus.java
@@ -1,0 +1,6 @@
+package com.kgu.life_watch.domain.chat.entity;
+
+public enum RoomStatus {
+  ACTIVATE,
+  DEACTIVATE // 활성화, 비활성화
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/entity/mapping/ChatParticipation.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/entity/mapping/ChatParticipation.java
@@ -1,0 +1,35 @@
+package com.kgu.life_watch.domain.chat.entity.mapping;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import com.kgu.life_watch.domain.chat.entity.ChatRoom;
+import com.kgu.life_watch.domain.user.entity.User;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChatParticipation {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  // 참여한 채팅방
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chat_room_id", nullable = false)
+  private ChatRoom chatRoom;
+
+  // 참여자
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/entity/mapping/ChatParticipation.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/entity/mapping/ChatParticipation.java
@@ -9,11 +9,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.kgu.life_watch.domain.chat.entity.ChatRoom;
 import com.kgu.life_watch.domain.user.entity.User;
 
+@Getter
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/kgu/life_watch/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,12 @@
+package com.kgu.life_watch.domain.chat.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kgu.life_watch.domain.chat.entity.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+  Optional<ChatMessage> findTopByChatRoomIdOrderByCreatedAtDesc(Long roomId);
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/repository/ChatParticipationRepository.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/repository/ChatParticipationRepository.java
@@ -1,0 +1,19 @@
+package com.kgu.life_watch.domain.chat.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.kgu.life_watch.domain.chat.entity.ChatRoom;
+import com.kgu.life_watch.domain.chat.entity.mapping.ChatParticipation;
+import com.kgu.life_watch.domain.user.entity.User;
+
+public interface ChatParticipationRepository extends JpaRepository<ChatParticipation, Long> {
+
+  @Query("SELECT cp FROM ChatParticipation cp WHERE cp.user.id = :userId")
+  List<ChatParticipation> findAllByUserId(Long userId);
+
+  @Query("SELECT cp.user FROM ChatParticipation cp WHERE cp.chatRoom = :chatRoom")
+  List<User> findUsersByChatRoom(ChatRoom chatRoom);
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.kgu.life_watch.domain.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kgu.life_watch.domain.chat.entity.ChatRoom;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {}

--- a/src/main/java/com/kgu/life_watch/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,76 @@
+package com.kgu.life_watch.domain.chat.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.kgu.life_watch.domain.chat.dto.ChatMessageDto;
+import com.kgu.life_watch.domain.chat.dto.response.ChatMessageResponse;
+import com.kgu.life_watch.domain.chat.entity.ChatMessage;
+import com.kgu.life_watch.domain.chat.entity.ChatRoom;
+import com.kgu.life_watch.domain.chat.repository.ChatMessageRepository;
+import com.kgu.life_watch.domain.chat.repository.ChatParticipationRepository;
+import com.kgu.life_watch.domain.chat.repository.ChatRoomRepository;
+import com.kgu.life_watch.domain.user.entity.User;
+import com.kgu.life_watch.domain.user.repository.UserRepository;
+import com.kgu.life_watch.global.exception.ErrorCode;
+import com.kgu.life_watch.global.exception.LifelineException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatMessageService {
+
+  private final ChatMessageRepository chatMessageRepository;
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatParticipationRepository chatParticipationRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public ChatMessage createChatMessage(ChatMessageDto request, String userId) {
+
+    User sender =
+        userRepository
+            .findById(Long.parseLong(userId))
+            .orElseThrow(() -> LifelineException.from(ErrorCode.MEMBER_NOT_FOUND));
+
+    ChatRoom chatRoom =
+        chatRoomRepository
+            .findById(request.roomId())
+            .orElseThrow(() -> LifelineException.from(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+    ChatMessage chatMessage = request.toEntity(chatRoom, sender);
+    chatMessageRepository.save(chatMessage);
+
+    chatRoom.addMessage(chatMessage);
+
+    return chatMessage;
+  }
+
+  @Transactional
+  public List<ChatMessageResponse> getMessagesByRoom(Long roomId, User user) {
+
+    ChatRoom chatRoom =
+        chatRoomRepository
+            .findById(roomId)
+            .orElseThrow(() -> LifelineException.from(ErrorCode.CHAT_ROOM_NOT_FOUND));
+    List<User> users = chatParticipationRepository.findUsersByChatRoom(chatRoom);
+    for (User findUser : users) {
+      if (user.getLoginId().equals(findUser.getLoginId())) break;
+      throw LifelineException.from(ErrorCode.CHAT_ROOM_NOT_OWNER);
+    }
+
+    List<ChatMessage> chatMessagesRoom = chatRoom.getChatMessages();
+    return ChatMessageResponse.fromEntitieList(chatMessagesRoom);
+  }
+
+  @Transactional
+  public Optional<ChatMessage> getLastMessage(Long roomId) {
+    return chatMessageRepository.findTopByChatRoomIdOrderByCreatedAtDesc(roomId);
+  }
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/service/ChatParticipationService.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/service/ChatParticipationService.java
@@ -1,0 +1,34 @@
+package com.kgu.life_watch.domain.chat.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.kgu.life_watch.domain.chat.entity.ChatRoom;
+import com.kgu.life_watch.domain.chat.entity.mapping.ChatParticipation;
+import com.kgu.life_watch.domain.chat.repository.ChatParticipationRepository;
+import com.kgu.life_watch.domain.user.entity.User;
+
+@Service
+@RequiredArgsConstructor
+public class ChatParticipationService {
+
+  private final ChatParticipationRepository chatParticipationRepository;
+
+  public void joinRoom(ChatRoom chatRoom, User me, User you) {
+    ChatParticipation participation1 =
+        chatParticipationRepository.save(
+            ChatParticipation.builder().chatRoom(chatRoom).user(me).build());
+    ChatParticipation participation2 =
+        chatParticipationRepository.save(
+            ChatParticipation.builder().chatRoom(chatRoom).user(you).build());
+    chatRoom.addParticipation(participation1);
+    chatRoom.addParticipation(participation2);
+  }
+
+  public List<ChatParticipation> getParticipationByUser(User user) {
+    return chatParticipationRepository.findAllByUserId(user.getId());
+  }
+}

--- a/src/main/java/com/kgu/life_watch/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/kgu/life_watch/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,153 @@
+package com.kgu.life_watch.domain.chat.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.kgu.life_watch.domain.chat.dto.response.ChatRoomResponse;
+import com.kgu.life_watch.domain.chat.entity.ChatMessage;
+import com.kgu.life_watch.domain.chat.entity.ChatRoom;
+import com.kgu.life_watch.domain.chat.entity.RoomStatus;
+import com.kgu.life_watch.domain.chat.entity.mapping.ChatParticipation;
+import com.kgu.life_watch.domain.chat.repository.ChatRoomRepository;
+import com.kgu.life_watch.domain.user.entity.User;
+import com.kgu.life_watch.domain.user.repository.UserRepository;
+import com.kgu.life_watch.global.exception.ErrorCode;
+import com.kgu.life_watch.global.exception.LifelineException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatRoomService {
+
+  private final UserRepository userRepository;
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatParticipationService chatParticipationService;
+  private final ChatMessageService chatMessageService;
+
+  /*
+  채팅방 생성 + 참여자 추가
+  */
+  @Transactional
+  public ChatRoomResponse createChatRoom(User user, Long receiverId) {
+
+    if (user == null) {
+      throw LifelineException.from(ErrorCode.INVALID_REQUEST);
+    }
+    if (Objects.equals(receiverId, user.getId())) {
+      throw LifelineException.from(ErrorCode.CHAT_ROOM_SELF);
+    }
+
+    User receiver =
+        userRepository
+            .findById(receiverId)
+            .orElseThrow(() -> LifelineException.from(ErrorCode.MEMBER_NOT_FOUND));
+
+    // 이미 해당 룸메이트와 채팅방을 만든 적이 있다면 채팅방 정보를 바로 리턴
+    List<ChatParticipation> chatParticipationList =
+        chatParticipationService.getParticipationByUser(user);
+    for (ChatParticipation chatParticipation : chatParticipationList) {
+      if (Objects.equals(
+              chatParticipation.getChatRoom().getParticipation().get(0).getUser().getId(),
+              receiver.getId())
+          || Objects.equals(
+              chatParticipation.getChatRoom().getParticipation().get(1).getUser().getId(),
+              user.getId())) {
+        ChatRoom existingChatRoom = chatParticipation.getChatRoom();
+        return ChatRoomResponse.fromEntity(
+            existingChatRoom,
+            receiver,
+            chatMessageService.getLastMessage(existingChatRoom.getId()).orElse(null));
+      }
+    }
+    ChatRoom chatRoom =
+        ChatRoom.builder().status(RoomStatus.ACTIVATE).createdAt(LocalDateTime.now()).build();
+
+    // 채팅방 생성 후 저장
+    ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+
+    // 생성된 채팅방의 참여자로 나랑 룸메를 저장
+    chatParticipationService.joinRoom(chatRoom, user, receiver);
+
+    // 아직 대화를 나누지 않아서 chat 내용은 null 처리
+    log.info("새로 만들었음.");
+
+    return ChatRoomResponse.fromEntity(savedChatRoom, receiver, null);
+  }
+
+  @Transactional
+  public List<ChatRoomResponse> getAllRoom(User user) {
+
+    List<ChatParticipation> chatParticipationList =
+        chatParticipationService.getParticipationByUser(user);
+    List<ChatRoomResponse> chatRooms = new ArrayList<>();
+
+    for (ChatParticipation chatParticipation : chatParticipationList) {
+
+      Long roomId = chatParticipation.getChatRoom().getId();
+      ChatRoom chatRoom =
+          chatRoomRepository
+              .findById(roomId)
+              .orElseThrow(() -> LifelineException.from(ErrorCode.CHAT_ROOM_NOT_FOUND));
+      if (chatRoom.getStatus() == RoomStatus.DEACTIVATE) {
+        continue;
+      }
+
+      Optional<ChatMessage> chatMessage = chatMessageService.getLastMessage(roomId);
+      List<ChatParticipation> usersInRoom = chatRoom.getParticipation();
+      // 룸메 객체를 추출
+      User receiver =
+          Objects.equals(usersInRoom.get(0).getUser().getId(), user.getId())
+              ? usersInRoom.get(1).getUser()
+              : usersInRoom.get(0).getUser();
+
+      chatRooms.add(ChatRoomResponse.fromEntity(chatRoom, receiver, chatMessage.orElse(null)));
+    }
+    chatRooms.sort(
+        (o1, o2) -> {
+          // o2의 메시지가 null인지 확인하고, null일 경우 생성시간으로 비교
+          LocalDateTime time1 = o1.lastMessageAt() != null ? o1.lastMessageAt() : o1.createdAt();
+          LocalDateTime time2 = o2.lastMessageAt() != null ? o2.lastMessageAt() : o2.createdAt();
+
+          return time2.compareTo(time1); // 최근 시간 순으로 정렬
+        });
+    return chatRooms;
+  }
+
+  @Transactional
+  // 유저들끼리 대화 중 문제가 생길 경우, 확인해야할 수 있으니 soft delete 만 지행
+  public void deleteRoom(Long roomId, User user) {
+
+    ChatRoom chatRoom =
+        chatRoomRepository
+            .findById(roomId)
+            .orElseThrow(() -> LifelineException.from(ErrorCode.CHAT_ROOM_NOT_FOUND));
+    boolean flag = false;
+    for (ChatParticipation chatParticipation : chatRoom.getParticipation()) {
+      if (Objects.equals(chatParticipation.getUser().getId(), user.getId())) {
+        flag = true;
+        break;
+      }
+    }
+    if (!flag) {
+      throw LifelineException.from(ErrorCode.CHAT_ROOM_NOT_PARTICIPANT);
+    }
+
+    chatRoom.updateStatus(RoomStatus.DEACTIVATE); // `deactivate`로 변경하면서 `soft delete`만 진행
+  }
+
+  @Transactional
+  public ChatRoom getChatRoom(Long roomId) {
+    return chatRoomRepository
+        .findById(roomId)
+        .orElseThrow(() -> LifelineException.from(ErrorCode.CHAT_ROOM_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/kgu/life_watch/domain/user/entity/User.java
+++ b/src/main/java/com/kgu/life_watch/domain/user/entity/User.java
@@ -12,12 +12,12 @@ import com.kgu.life_watch.global.domain.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "`user`")
+@Table(name = "users")
 public class User extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long userId;
+  private Long id;
 
   @Column(nullable = false)
   private String name;

--- a/src/main/java/com/kgu/life_watch/domain/user/repository/ElderlyProfileRepository.java
+++ b/src/main/java/com/kgu/life_watch/domain/user/repository/ElderlyProfileRepository.java
@@ -1,0 +1,7 @@
+package com.kgu.life_watch.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kgu.life_watch.domain.user.entity.ElderlyProfile;
+
+public interface ElderlyProfileRepository extends JpaRepository<ElderlyProfile, Long> {}

--- a/src/main/java/com/kgu/life_watch/domain/user/repository/SocialWorkerProfileRepository.java
+++ b/src/main/java/com/kgu/life_watch/domain/user/repository/SocialWorkerProfileRepository.java
@@ -1,0 +1,7 @@
+package com.kgu.life_watch.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kgu.life_watch.domain.user.entity.SocialWorkerProfile;
+
+public interface SocialWorkerProfileRepository extends JpaRepository<SocialWorkerProfile, Long> {}

--- a/src/main/java/com/kgu/life_watch/global/config/SecurityConfig.java
+++ b/src/main/java/com/kgu/life_watch/global/config/SecurityConfig.java
@@ -59,7 +59,8 @@ public class SecurityConfig {
                         "/api-docs",
                         "/api-docs/**",
                         "/v1/api-docs/**",
-                        "/health/**")
+                        "/health/**",
+                        "/chat/**")
                     .permitAll()
                     .requestMatchers("/api/auth/**")
                     .permitAll() // 로그인과 회원가입은 인증 없이 접근 가능
@@ -78,7 +79,10 @@ public class SecurityConfig {
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOrigins(
-        Arrays.asList("http://localhost:3000", "http://localhost:8080")); // 추후에 배포시 수정 필요
+        Arrays.asList(
+            "http://localhost:3000",
+            "http://localhost:8080",
+            "https://jiangxy.github.io")); // 추후에 배포시 수정 필요
     configuration.setAllowedMethods(
         Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD")); // 허용할 HTTP 메서드
     configuration.setAllowedHeaders(

--- a/src/main/java/com/kgu/life_watch/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kgu/life_watch/global/config/WebSocketConfig.java
@@ -1,0 +1,33 @@
+package com.kgu.life_watch.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+
+    // socketJs 클라이언트가 WebSocket 핸드셰이크를 하기 위해 연결할 endpoint를 지정할 수 있다.
+    registry
+        .addEndpoint("/chat/inbox")
+        .setAllowedOriginPatterns("*") // cors 허용을 위해 꼭 설정해주어야 한다.
+        .withSockJS(); // 웹소켓을 지원하지 않는 브라우저는 sockJS를 사용하도록 한다.
+  }
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    // 메모리 기반 메시지 브로커가 해당 api를 구독하고 있는 클라이언트에게 메시지를 전달한다.
+    // to subscriber
+    registry.enableSimpleBroker("/sub");
+
+    // 클라이언트로부터 메시지를 받을 api의 prefix를 설정한다.
+    // publish
+    registry.setApplicationDestinationPrefixes("/pub");
+  }
+}

--- a/src/main/java/com/kgu/life_watch/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kgu/life_watch/global/config/WebSocketConfig.java
@@ -1,23 +1,27 @@
 package com.kgu.life_watch.global.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import lombok.RequiredArgsConstructor;
+
+import com.kgu.life_watch.global.handler.StompHandler;
+
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  private final StompHandler stompHandler;
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
 
-    // socketJs 클라이언트가 WebSocket 핸드셰이크를 하기 위해 연결할 endpoint를 지정할 수 있다.
-    registry
-        .addEndpoint("/chat/inbox")
-        .setAllowedOriginPatterns("*") // cors 허용을 위해 꼭 설정해주어야 한다.
-        .withSockJS(); // 웹소켓을 지원하지 않는 브라우저는 sockJS를 사용하도록 한다.
+    registry.addEndpoint("/chat").setAllowedOriginPatterns("*"); // cors 허용을 위해 꼭 설정해주어야
   }
 
   @Override
@@ -29,5 +33,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     // 클라이언트로부터 메시지를 받을 api의 prefix를 설정한다.
     // publish
     registry.setApplicationDestinationPrefixes("/pub");
+  }
+
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(stompHandler);
   }
 }

--- a/src/main/java/com/kgu/life_watch/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kgu/life_watch/global/config/WebSocketConfig.java
@@ -21,7 +21,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
 
-    registry.addEndpoint("/chat").setAllowedOriginPatterns("*"); // cors 허용을 위해 꼭 설정해주어야
+    registry.addEndpoint("/chat").setAllowedOriginPatterns("*"); // 추후 배포시 수정 필요
   }
 
   @Override

--- a/src/main/java/com/kgu/life_watch/global/handler/StompHandler.java
+++ b/src/main/java/com/kgu/life_watch/global/handler/StompHandler.java
@@ -1,0 +1,101 @@
+package com.kgu.life_watch.global.handler;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.kgu.life_watch.domain.user.entity.User;
+import com.kgu.life_watch.domain.user.repository.UserRepository;
+import com.kgu.life_watch.global.exception.ErrorCode;
+import com.kgu.life_watch.global.exception.LifelineException;
+import com.kgu.life_watch.global.jwt.JwtTokenProvider;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class StompHandler implements ChannelInterceptor {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final UserRepository userRepository;
+
+  //  @Override
+  //  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+  //    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+  //
+  //    if (accessor.getCommand() == StompCommand.CONNECT) {
+  //      String accessToken = accessor.getFirstNativeHeader("Authorization");
+  //
+  //      if (accessToken == null) {
+  //        throw LifelineException.from(ErrorCode.INVALID_AUTH_TOKEN);
+  //      }
+  //
+  //      accessToken = resolveToken(accessToken);
+  //
+  //      if (!jwtTokenProvider.validateToken(accessToken)) {
+  //        throw LifelineException.from(ErrorCode.INVALID_AUTH_TOKEN);
+  //      }
+  //
+  //      if (accessToken == null) {
+  //        throw LifelineException.from(ErrorCode.INVALID_AUTH_TOKEN);
+  //      }
+  //
+  //      String loginId = jwtTokenProvider.getLoginIdFromToken(accessToken);
+  //      User findUser = userRepository.findByLoginId(loginId).orElse(null);
+  //
+  //      if (findUser == null) {
+  //        throw LifelineException.from(ErrorCode.MEMBER_NOT_FOUND);
+  //      }
+  //      accessor.getSessionAttributes().put("senderUserId", findUser.getId().toString());
+  //    }
+  //
+  //    return message;
+  //  }
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+    if (accessor.getCommand() == StompCommand.CONNECT) {
+      String accessToken = accessor.getFirstNativeHeader("Authorization");
+
+      if (accessToken == null) {
+        throw LifelineException.from(ErrorCode.INVALID_AUTH_TOKEN);
+      }
+
+      accessToken = resolveToken(accessToken);
+
+      if (!jwtTokenProvider.validateToken(accessToken)) {
+        throw LifelineException.from(ErrorCode.INVALID_AUTH_TOKEN);
+      }
+
+      if (accessToken == null) {
+        throw LifelineException.from(ErrorCode.INVALID_AUTH_TOKEN);
+      }
+
+      String loginId = jwtTokenProvider.getLoginIdFromToken(accessToken);
+
+      User findUser = userRepository.findByLoginId(loginId).orElse(null);
+
+      if (findUser == null) {
+        throw LifelineException.from(ErrorCode.MEMBER_NOT_FOUND);
+      }
+
+      accessor.getSessionAttributes().put("senderUserId", findUser.getId().toString());
+    }
+
+    return message;
+  }
+
+  private String resolveToken(String bearerToken) {
+    // Bearer 토큰 파싱
+    if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## ⏰ Summary
일단 회원가입 부분이 `User`쪽이 cascade로 설정되어 있어서 연관관계 주인인 ElderlyProfile이나 SocialWorkerProfile에서 저장하면 user도 저장돼서 그렇게 바꿨어요.

실시간 채팅을 STOMP를 이용해서 구현했읍니다.
실시간이긴 한데, DB에 채팅 메시지 저장해서 웹소켓에 연결되어있지 않아도 DB 메시지 쌓이도록 했습니다.

---
![image](https://github.com/user-attachments/assets/4958833f-eabe-48be-905b-10a4cc2147c5)
### 1:1 채팅 흐름
1. 웹소켓 연결
- 클라이언트는 서버와 WebSocket을 통해 연결을 수립합니다. 이때, 연결은 실시간 메시지 전송을 위한 준비 상태입니다.

2. 채팅방 구독
- 사용자는 자신과 상대방만의 고유한 채팅방을 구독합니다. 예를 들어, 사용자가 userA와 userB 간의 채팅을 원할 경우, `/sub/channel/1`와 같이 고유한 채팅방 경로를 구독합니다.

3. 메시지 전송
- 사용자가 메시지를 입력하여 서버로 전송하면, 서버는 해당 채팅방에 구독된 상대방에게 실시간으로 메시지를 전달합니다. 이 메시지는 채팅방에 구독된 모든 사용자에게 전달됩니다.

4. 메시지 수신
- 채팅방에 구독된 사용자들은 서버로부터 실시간으로 메시지를 수신하고, 이를 화면에 표시합니다.

5. 연결 해제
- 채팅을 종료하거나 연결을 끊을 때, 클라이언트는 WebSocket 연결을 종료합니다.
---

대충 이런 구조로 동작해요.

궁금한 부분 있으면 카톡주세요!

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #8


## 🙏 To Reviewers

### 회원가입관련
<img width="642" alt="image" src="https://github.com/user-attachments/assets/85cbbdbd-7c5b-4837-b077-6d15cac562ac" />
<br>
사회복지사 정보 ERD에 담당노인 목록 String으로 되어있는데, 저거 따로 테이블빼서 관리해야할 거 같고, 엔티티랑 회원가입로직, 사회복지사 회원가입 DTO 수정해야 할듯합니다..!

### 채팅 관련
일단 1차적으로 기능 구현에 집중해서 PR올렸고, 빠른 시일 내에 필요한 기능들 ( ex) 채팅방 삭제, 채팅방 리스트 불러오기) 등등 기능도 구현하겠습니당